### PR TITLE
Allow Socket.IO to negotiate transport

### DIFF
--- a/trading_bot/static/index.html
+++ b/trading_bot/static/index.html
@@ -266,7 +266,7 @@
         statusLabel.textContent = connected ? "online" : "offline";
       }
 
-      const socket = io("/quotes", { transports: ["websocket"] });
+      const socket = io("/quotes");
       socket.on("connect", () => updateStatus(true));
       socket.on("disconnect", () => updateStatus(false));
       socket.on("candle", (payload) => {


### PR DESCRIPTION
## Summary
- remove the hard-coded websocket-only transport so the Socket.IO client can negotiate with the Flask server

## Testing
- python -m trading_bot.app
- curl -s 'http://127.0.0.1:5000/socket.io/?EIO=4&transport=polling'


------
https://chatgpt.com/codex/tasks/task_e_68cfb4ef460c832c88870d7d4558a50a