### PR TITLE
Ensure live profit percent is exposed for open trades

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -109,7 +109,9 @@ class Trade:
             "max_profit_pct": self.max_profit_pct,
             "exit_price": self.exit_price,
             "closed_at": self.closed_at.isoformat() if self.closed_at else None,
-            "profit_pct": self.profit_pct,
+            "profit_pct": self.profit_pct
+            if self.profit_pct is not None
+            else self.current_profit_pct,
             "status": "active" if self.is_active else "closed",
         }
 


### PR DESCRIPTION
## Summary
- ensure Trade.to_dict returns current profit percent when a trade is still open

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfc8c03534832cb08547a39615ac80