### PR TITLE
Switch UI from REST polling to WebSocket updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ collection, strategy evaluation and trade management.
 - **`module_worker.py`** – Launches modules on independent threads and funnels
   signals to the orchestrator through a queue.
 - **`orchestrator.py`** – Flask + Socket.IO service that manages trades,
-  applies trailing stops and exposes a JSON API for the UI.
-- **`client.html`** – Lightweight dashboard polling `/api/ui_trades` every two
-  seconds to display open and closed positions.
+  applies trailing stops and streams updates to the UI over WebSocket.
+- **`client.html`** – Lightweight dashboard that subscribes to WebSocket
+  updates to display open and closed positions in real time.
 
 ## Running locally
 

--- a/binance_client.py
+++ b/binance_client.py
@@ -190,6 +190,17 @@ class BinanceClient:
         if self._liquidity_thread and self._liquidity_thread.is_alive():
             self._liquidity_thread.join(timeout=2.0)
 
+    def clear_caches(self) -> None:
+        """Clear local price, kline and liquidity caches."""
+
+        with self._price_lock:
+            self._price_cache.clear()
+        with self._klines_lock:
+            self._klines_cache.clear()
+        with self._liquidity_lock:
+            self._liquid_pairs.clear()
+            self._last_liquidity_refresh = 0.0
+
     # ------------------------------- Price handling -------------------
     def subscribe_ticker(self, symbols: Iterable[str]) -> None:
         """Subscribe the ticker updater to additional symbols."""

--- a/client.html
+++ b/client.html
@@ -628,6 +628,7 @@
   const STRATEGY_ALL = '__all__';
   let tradesData = { active: [], closed: [] };
   let selectedStrategy = STRATEGY_ALL;
+  let socket = null;
 
   function nfix(value, digits = 4) {
     const num = Number(value);
@@ -696,16 +697,39 @@
     return result;
   }
 
-  async function fetchUiTrades() {
-    try {
-      const response = await fetch('/api/ui_trades');
-      if (!response.ok) throw new Error('HTTP ' + response.status);
-      const data = await response.json();
-      tradesData = normalizeTradesData(data);
-      updateUI();
-    } catch (error) {
-      console.warn('[UI] fetch /api/ui_trades failed:', error.message);
-    }
+  function handleTradesPayload(payload) {
+    tradesData = normalizeTradesData(payload);
+    updateUI();
+  }
+
+  function requestTradesState() {
+    if (!socket || !socket.connected) return;
+    socket.emit('request_state');
+  }
+
+  function setupSocket() {
+    socket = io({ transports: ['websocket'], autoConnect: true });
+
+    socket.on('connect', () => {
+      console.info('[WS] connected');
+      requestTradesState();
+    });
+
+    socket.on('disconnect', (reason) => {
+      console.warn('[WS] disconnected:', reason);
+    });
+
+    socket.on('connect_error', (error) => {
+      console.warn('[WS] connect error:', error.message || error);
+    });
+
+    socket.on('trades', handleTradesPayload);
+  }
+
+  function ensureSocketConnected() {
+    if (socket && socket.connected) return true;
+    alert('Нет соединения с сервером');
+    return false;
   }
 
   function getFilteredTrades() {
@@ -911,8 +935,7 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    fetchUiTrades();
-    setInterval(fetchUiTrades, 2000);
+    setupSocket();
 
     document.getElementById('strategyToggle').addEventListener('click', toggleStrategyPanel);
     document.getElementById('strategyClose').addEventListener('click', closeStrategyPanel);
@@ -926,32 +949,42 @@
     updateUI();
   });
 
-  async function closeAllTrades() {
-    try {
-      const response = await fetch('/api/close_all', {
-        method: 'POST'
+  function closeAllTrades() {
+    if (!ensureSocketConnected()) return;
+
+    socket
+      .timeout(5000)
+      .emit('close_all_trades', {}, (err, response) => {
+        if (err) {
+          alert('Сервер не ответил вовремя');
+          return;
+        }
+        if (response && response.status === 'ok') {
+          alert(`Закрыто ${response.count} сделок`);
+          requestTradesState();
+        } else {
+          alert('Ошибка при закрытии сделок');
+        }
       });
-      if (!response.ok) throw new Error('HTTP ' + response.status);
-      const data = await response.json();
-      alert(`Закрыто ${data.count} сделок`);
-      fetchUiTrades();
-    } catch (error) {
-      alert('Ошибка при закрытии сделок');
-    }
   }
 
-  async function clearCache() {
-    try {
-      const response = await fetch('/api/clear_cache', {
-        method: 'POST'
+  function clearCache() {
+    if (!ensureSocketConnected()) return;
+
+    socket
+      .timeout(5000)
+      .emit('clear_cache', {}, (err, response) => {
+        if (err) {
+          alert('Сервер не ответил вовремя');
+          return;
+        }
+        if (response && response.status === 'ok') {
+          alert('Кеш очищен');
+          requestTradesState();
+        } else {
+          alert('Ошибка при очистке кеша');
+        }
       });
-      if (!response.ok) throw new Error('HTTP ' + response.status);
-      await response.json();
-      alert('Кеш очищен');
-      fetchUiTrades();
-    } catch (error) {
-      alert('Ошибка при очистке кеша');
-    }
   }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the Flask REST endpoint with Socket.IO handlers that broadcast state, close trades and clear caches
- update the browser client to consume trade updates via WebSocket and issue management commands through the same connection
- add a cache-reset helper to the Binance client and refresh the README to describe the new transport

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cfd17f989c832c8d712dd03ec1e170