### PR TITLE
Allow Socket.IO fallback transports

### DIFF
--- a/client.html
+++ b/client.html
@@ -708,7 +708,7 @@
   }
 
   function setupSocket() {
-    socket = io({ transports: ['websocket'], autoConnect: true });
+    socket = io({ transports: ['polling', 'websocket'], autoConnect: true });
 
     socket.on('connect', () => {
       console.info('[WS] connected');


### PR DESCRIPTION
## Summary
- allow the browser Socket.IO client to fall back to HTTP polling so it can connect when native websockets are unavailable

## Testing
- python orchestrator.py
- python - <<'PY'  # python-socketio polling connection check

------
https://chatgpt.com/codex/tasks/task_e_68cfdc8ebbfc832cb77586d4aa931587