### PR TITLE
Add additional strategy modules

### DIFF
--- a/modules/strategy_mean_reversion.py
+++ b/modules/strategy_mean_reversion.py
@@ -1,0 +1,64 @@
+"""Mean reversion strategy using z-score of the last close."""
+
+from __future__ import annotations
+
+from statistics import fmean, pstdev
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class MeanReversionStrategy(ModuleBase):
+    """Fade extremes when price deviates strongly from its moving average."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "15m",
+        lookback: int = 120,
+        window: int = 20,
+        z_threshold: float = 2.0,
+    ) -> None:
+        minimum_history = max(lookback, window + 2)
+        super().__init__(
+            client,
+            name="MeanReversion",
+            abbreviation="MRV",
+            interval=interval,
+            lookback=minimum_history,
+        )
+        self._window = window
+        self._z_threshold = z_threshold
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) <= self._window:
+            return []
+
+        closes = [candle.close for candle in candles]
+        lookback_slice = closes[-self._window :]
+        avg_close = fmean(lookback_slice)
+        deviation = pstdev(lookback_slice)
+        if deviation == 0:
+            return []
+
+        last_close = closes[-1]
+        z_score = (last_close - avg_close) / deviation
+        metadata = {
+            "mean": avg_close,
+            "std_dev": deviation,
+            "z_score": z_score,
+            "last_close": last_close,
+        }
+
+        if z_score >= self._z_threshold:
+            return [self.make_signal(symbol, "SHORT", confidence=0.9, metadata=metadata)]
+
+        if z_score <= -self._z_threshold:
+            return [self.make_signal(symbol, "LONG", confidence=0.9, metadata=metadata)]
+
+        return []
+
+
+__all__ = ["MeanReversionStrategy"]

--- a/modules/strategy_momentum_factor.py
+++ b/modules/strategy_momentum_factor.py
@@ -1,0 +1,60 @@
+"""Momentum factor strategy measuring percentage change over N bars."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class MomentumFactorStrategy(ModuleBase):
+    """Capture short term momentum bursts in the direction of the trend."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "15m",
+        lookback: int = 60,
+        momentum_window: int = 10,
+        threshold: float = 0.01,
+    ) -> None:
+        minimum_history = max(lookback, momentum_window + 2)
+        super().__init__(
+            client,
+            name="MomentumFactor",
+            abbreviation="MOM",
+            interval=interval,
+            lookback=minimum_history,
+        )
+        self._momentum_window = momentum_window
+        self._threshold = threshold
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) <= self._momentum_window:
+            return []
+
+        closes = [c.close for c in candles]
+        current_close = closes[-1]
+        reference_close = closes[-self._momentum_window]
+        if reference_close == 0:
+            return []
+
+        ret = (current_close / reference_close) - 1.0
+        metadata = {
+            "return": ret,
+            "current_close": current_close,
+            "reference_close": reference_close,
+        }
+
+        if ret >= self._threshold:
+            return [self.make_signal(symbol, "LONG", confidence=1.0, metadata=metadata)]
+
+        if ret <= -self._threshold:
+            return [self.make_signal(symbol, "SHORT", confidence=1.0, metadata=metadata)]
+
+        return []
+
+
+__all__ = ["MomentumFactorStrategy"]

--- a/modules/strategy_pattern_recognition.py
+++ b/modules/strategy_pattern_recognition.py
@@ -1,0 +1,68 @@
+"""Basic candlestick pattern recognition strategy."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class PatternRecognitionStrategy(ModuleBase):
+    """Look for simple two-candle reversal formations on 15 minute bars."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "15m",
+        lookback: int = 40,
+    ) -> None:
+        super().__init__(
+            client,
+            name="PatternRecognition",
+            abbreviation="PAT",
+            interval=interval,
+            lookback=max(lookback, 10),
+        )
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) < 2:
+            return []
+
+        prev = candles[-2]
+        curr = candles[-1]
+        signals: List[Signal] = []
+
+        bullish_setup = (
+            prev.close < prev.open
+            and curr.close > curr.open
+            and curr.close > prev.close
+        )
+        if bullish_setup:
+            metadata = {
+                "prev_open": prev.open,
+                "prev_close": prev.close,
+                "curr_open": curr.open,
+                "curr_close": curr.close,
+            }
+            signals.append(self.make_signal(symbol, "LONG", confidence=0.85, metadata=metadata))
+
+        bearish_setup = (
+            prev.close > prev.open
+            and curr.close < curr.open
+            and curr.close < prev.close
+        )
+        if bearish_setup:
+            metadata = {
+                "prev_open": prev.open,
+                "prev_close": prev.close,
+                "curr_open": curr.open,
+                "curr_close": curr.close,
+            }
+            signals.append(self.make_signal(symbol, "SHORT", confidence=0.85, metadata=metadata))
+
+        return signals
+
+
+__all__ = ["PatternRecognitionStrategy"]

--- a/modules/strategy_range_breakout.py
+++ b/modules/strategy_range_breakout.py
@@ -1,0 +1,85 @@
+"""Range breakout strategy focused on intraday levels."""
+
+from __future__ import annotations
+
+from statistics import fmean
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class RangeBreakoutStrategy(ModuleBase):
+    """Identify breakouts from a recent trading range on 15 minute bars."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "15m",
+        lookback: int = 60,
+        breakout_window: int = 20,
+        volume_window: int = 20,
+    ) -> None:
+        minimum_history = max(breakout_window + 2, volume_window + 2, lookback)
+        super().__init__(
+            client,
+            name="RangeBreakout",
+            abbreviation="RBO",
+            interval=interval,
+            lookback=minimum_history,
+        )
+        self._breakout_window = breakout_window
+        self._volume_window = volume_window
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) < self._breakout_window + 1:
+            return []
+
+        breakout_candle = candles[-1]
+        prev_candle = candles[-2]
+        window = candles[-(self._breakout_window + 1) : -1]
+        resistance = max(candle.high for candle in window)
+        support = min(candle.low for candle in window)
+
+        avg_volume = None
+        if len(candles) > self._volume_window:
+            volume_slice = candles[-(self._volume_window + 1) : -1]
+            avg_volume = fmean(c.volume for c in volume_slice)
+
+        signals: List[Signal] = []
+
+        if breakout_candle.close > resistance and prev_candle.close <= resistance:
+            metadata = {
+                "breakout_level": resistance,
+                "previous_close": prev_candle.close,
+                "current_close": breakout_candle.close,
+            }
+            if avg_volume is not None:
+                metadata.update(
+                    {
+                        "volume": breakout_candle.volume,
+                        "avg_volume": avg_volume,
+                    }
+                )
+            signals.append(self.make_signal(symbol, "LONG", confidence=1.05, metadata=metadata))
+
+        if breakout_candle.close < support and prev_candle.close >= support:
+            metadata = {
+                "breakdown_level": support,
+                "previous_close": prev_candle.close,
+                "current_close": breakout_candle.close,
+            }
+            if avg_volume is not None:
+                metadata.update(
+                    {
+                        "volume": breakout_candle.volume,
+                        "avg_volume": avg_volume,
+                    }
+                )
+            signals.append(self.make_signal(symbol, "SHORT", confidence=1.05, metadata=metadata))
+
+        return signals
+
+
+__all__ = ["RangeBreakoutStrategy"]

--- a/modules/strategy_volatility_breakout.py
+++ b/modules/strategy_volatility_breakout.py
@@ -1,0 +1,70 @@
+"""ATR style volatility breakout strategy."""
+
+from __future__ import annotations
+
+from statistics import fmean
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class VolatilityBreakoutStrategy(ModuleBase):
+    """Trigger when price expands beyond the recent range by an ATR multiple."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "15m",
+        lookback: int = 80,
+        atr_period: int = 15,
+        atr_multiplier: float = 1.0,
+    ) -> None:
+        minimum_history = max(lookback, atr_period + 2)
+        super().__init__(
+            client,
+            name="VolatilityBreakout",
+            abbreviation="VBO",
+            interval=interval,
+            lookback=minimum_history,
+        )
+        self._atr_period = atr_period
+        self._atr_multiplier = atr_multiplier
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) <= self._atr_period:
+            return []
+
+        last = candles[-1]
+        prev = candles[-2]
+        atr_sample = candles[-self._atr_period :]
+        ranges = [candle.high - candle.low for candle in atr_sample]
+        atr_value = fmean(ranges)
+        threshold = atr_value * self._atr_multiplier
+
+        signals: List[Signal] = []
+        price_delta = last.close - prev.close
+
+        if price_delta > threshold:
+            metadata = {
+                "atr": atr_value,
+                "previous_close": prev.close,
+                "current_close": last.close,
+                "change": price_delta,
+            }
+            signals.append(self.make_signal(symbol, "LONG", confidence=1.0, metadata=metadata))
+
+        if price_delta < -threshold:
+            metadata = {
+                "atr": atr_value,
+                "previous_close": prev.close,
+                "current_close": last.close,
+                "change": price_delta,
+            }
+            signals.append(self.make_signal(symbol, "SHORT", confidence=1.0, metadata=metadata))
+
+        return signals
+
+
+__all__ = ["VolatilityBreakoutStrategy"]

--- a/modules/strategy_volume_trend.py
+++ b/modules/strategy_volume_trend.py
@@ -1,0 +1,72 @@
+"""Volume weighted trend following strategy."""
+
+from __future__ import annotations
+
+from statistics import fmean
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class VolumeWeightedTrendStrategy(ModuleBase):
+    """Look for strong moves supported by a surge in traded volume."""
+
+    def __init__(
+        self,
+        client,
+        *,
+        interval: str = "5m",
+        lookback: int = 80,
+        volume_window: int = 20,
+        momentum_window: int = 5,
+        volume_multiplier: float = 1.5,
+    ) -> None:
+        minimum_history = max(
+            lookback,
+            volume_window + 2,
+            momentum_window + 2,
+        )
+        super().__init__(
+            client,
+            name="VolumeWeightedTrend",
+            abbreviation="VWT",
+            interval=interval,
+            lookback=minimum_history,
+        )
+        self._volume_window = volume_window
+        self._momentum_window = momentum_window
+        self._volume_multiplier = volume_multiplier
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) <= max(self._volume_window, self._momentum_window):
+            return []
+
+        closes = [c.close for c in candles]
+        last_close = closes[-1]
+        momentum_reference = closes[-self._momentum_window]
+
+        volume_slice = candles[-self._volume_window :]
+        avg_volume = fmean(c.volume for c in volume_slice)
+        current_volume = candles[-1].volume
+
+        if avg_volume <= 0 or current_volume <= avg_volume * self._volume_multiplier:
+            return []
+
+        metadata = {
+            "avg_volume": avg_volume,
+            "current_volume": current_volume,
+            "momentum_reference": momentum_reference,
+            "last_close": last_close,
+        }
+
+        if last_close > momentum_reference:
+            return [self.make_signal(symbol, "LONG", confidence=1.05, metadata=metadata)]
+
+        if last_close < momentum_reference:
+            return [self.make_signal(symbol, "SHORT", confidence=1.05, metadata=metadata)]
+
+        return []
+
+
+__all__ = ["VolumeWeightedTrendStrategy"]

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -20,8 +20,14 @@ from module_worker import ModuleWorker
 from modules.strategy_breakout import BreakoutHighLowStrategy
 from modules.strategy_engulf import EngulfingStrategy
 from modules.strategy_inside import InsideBarBreakoutStrategy
+from modules.strategy_mean_reversion import MeanReversionStrategy
+from modules.strategy_momentum_factor import MomentumFactorStrategy
+from modules.strategy_pattern_recognition import PatternRecognitionStrategy
 from modules.strategy_pinbar import PinBarStrategy
+from modules.strategy_range_breakout import RangeBreakoutStrategy
 from modules.strategy_trend import EMABounceStrategy
+from modules.strategy_volume_trend import VolumeWeightedTrendStrategy
+from modules.strategy_volatility_breakout import VolatilityBreakoutStrategy
 
 
 @dataclass
@@ -207,6 +213,12 @@ class Orchestrator:
             InsideBarBreakoutStrategy(self.client),
             BreakoutHighLowStrategy(self.client),
             EMABounceStrategy(self.client),
+            RangeBreakoutStrategy(self.client),
+            VolatilityBreakoutStrategy(self.client),
+            MeanReversionStrategy(self.client),
+            VolumeWeightedTrendStrategy(self.client),
+            MomentumFactorStrategy(self.client),
+            PatternRecognitionStrategy(self.client),
         ]
         return modules
 


### PR DESCRIPTION
## Summary
- add range breakout, volatility breakout, mean reversion, volume trend, momentum, and pattern recognition strategy modules
- wire the new modules into the orchestrator so they run alongside existing strategies

## Testing
- python -m compileall MyMarket

------
https://chatgpt.com/codex/tasks/task_e_68d08770dc34832caaa0592a2062a971