### PR TITLE
Auto-discover strategy modules in orchestrator

### DIFF
--- a/module_base.py
+++ b/module_base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Literal, Sequence
+from typing import Dict, Iterable, List, Literal, Optional, Sequence
 
 from binance_client import BinanceClient, Kline
 
@@ -77,6 +77,18 @@ class ModuleBase(ABC):
     @abstractmethod
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         """Inspect the provided candles and yield signals."""
+
+    # ------------------------------------------------------------------
+    def run(self, symbol: str, candles: Sequence[Kline]) -> Optional[Signal]:
+        """Execute the strategy for a single symbol.
+
+        The default implementation delegates to :meth:`process` and returns the
+        first signal emitted, if any.  Strategies are free to override this if
+        they prefer a different behaviour.
+        """
+
+        signals = list(self.process(symbol, candles))
+        return signals[0] if signals else None
 
     # ------------------------------------------------------------------
     def make_signal(

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,21 +1,9 @@
-"""Collection of strategy modules exposed by the package."""
+"""Strategy modules package.
 
-from .strategy_atr_ema_breakout import ATRBreakoutStrategy
-from .strategy_engulfing_rsi import EngulfingRSIStrategy
-from .strategy_inside_breakout import InsideBarVolumeBreakoutStrategy
-from .strategy_pinbar_level import PinBarLevelStrategy
-from .strategy_vwap_reversal import VWAPTrendReversalStrategy
-from .strategy_triple_ema import TripleEMASqueezeStrategy
-from .strategy_rsi_divergence import RSIDivergenceStrategy
-from .strategy_bollinger_squeeze import BollingerSqueezeBreakoutStrategy
+The orchestrator is responsible for discovering strategy implementations at
+runtime, therefore this package only needs to exist so Python treats
+``modules/`` as a namespace.  Keeping the ``__all__`` list empty prevents us
+from having to update it whenever a new strategy file is added.
+"""
 
-__all__ = [
-    "ATRBreakoutStrategy",
-    "EngulfingRSIStrategy",
-    "InsideBarVolumeBreakoutStrategy",
-    "PinBarLevelStrategy",
-    "VWAPTrendReversalStrategy",
-    "TripleEMASqueezeStrategy",
-    "RSIDivergenceStrategy",
-    "BollingerSqueezeBreakoutStrategy",
-]
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- add runtime discovery of strategy modules in the orchestrator and expose them as a dictionary
- extend ModuleBase with a default run helper so interface validation succeeds for discovered classes
- simplify the modules package so strategies can be dropped in without manual registration

## Testing
- python -m compileall orchestrator.py module_base.py modules

------
https://chatgpt.com/codex/tasks/task_e_68d0a29e9330832ca9ba1297101aec70