### PR TITLE
Add multi-timeframe configuration support

### DIFF
--- a/module_base.py
+++ b/module_base.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Literal, Optional, Sequence
+from typing import Dict, Iterable, List, Literal, Mapping, Optional, Sequence
 
 from binance_client import BinanceClient, Kline
+from multi_timeframe_config import MULTI_TIMEFRAME_CONFIG
 
 SignalSide = Literal["LONG", "SHORT"]
 
@@ -29,7 +30,10 @@ class ModuleBase(ABC):
     """Common utilities for strategy modules.
 
     Sub-classes must implement :meth:`process` that inspects a sequence of
-    klines and returns zero or more :class:`Signal` instances.
+    klines and returns zero or more :class:`Signal` instances.  Multi-timeframe
+    strategies can either declare their additional requirements via
+    ``multi_timeframe_config`` or override :meth:`process_with_timeframes` to
+    handle the extra candle data.
     """
 
     def __init__(
@@ -40,12 +44,19 @@ class ModuleBase(ABC):
         abbreviation: str,
         interval: str,
         lookback: int,
+        extra_timeframes: Mapping[str, int] | None = None,
     ) -> None:
         self.client = client
         self.name = name
         self.abbreviation = abbreviation
         self.interval = interval
         self.lookback = lookback
+        if extra_timeframes is not None:
+            self.extra_timeframes: Dict[str, int] = dict(extra_timeframes)
+        else:
+            self.extra_timeframes = dict(
+                MULTI_TIMEFRAME_CONFIG.get(self.abbreviation, {})
+            )
 
     @property
     def minimum_bars(self) -> int:
@@ -60,14 +71,41 @@ class ModuleBase(ABC):
         results: List[Signal] = []
         for symbol in symbols:
             try:
-                candles = self.client.fetch_klines(symbol, self.interval, self.lookback)
+                primary_candles = self.client.fetch_klines(
+                    symbol, self.interval, self.lookback
+                )
             except Exception:  # pragma: no cover - defensive
                 _logger.exception("failed to fetch klines for %s", symbol)
                 continue
-            if len(candles) < self.minimum_bars:
+            if len(primary_candles) < self.minimum_bars:
+                continue
+
+            extra_candles: Dict[str, Sequence[Kline]] = {}
+            missing_timeframe_data = False
+            for extra_interval, extra_lookback in self.extra_timeframes.items():
+                try:
+                    candles = self.client.fetch_klines(
+                        symbol, extra_interval, extra_lookback
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    _logger.exception(
+                        "failed to fetch %s klines for %s", extra_interval, symbol
+                    )
+                    missing_timeframe_data = True
+                    break
+                if len(candles) < extra_lookback:
+                    missing_timeframe_data = True
+                    break
+                extra_candles[extra_interval] = candles
+
+            if missing_timeframe_data:
                 continue
             try:
-                signals = list(self.process(symbol, candles))
+                signals = list(
+                    self.process_with_timeframes(
+                        symbol, primary_candles, extra_candles
+                    )
+                )
                 results.extend(signals)
             except Exception:  # pragma: no cover - defensive
                 _logger.exception("module %s failed for %s", self.name, symbol)
@@ -77,6 +115,23 @@ class ModuleBase(ABC):
     @abstractmethod
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         """Inspect the provided candles and yield signals."""
+
+    # ------------------------------------------------------------------
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Mapping[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
+        """Inspect candles from the primary and any additional timeframes.
+
+        The default implementation delegates to :meth:`process` for backward
+        compatibility so that existing single-timeframe modules continue to
+        function without modification.  Multi-timeframe strategies can override
+        this hook to consume the ``extra_candles`` mapping.
+        """
+
+        return self.process(symbol, primary_candles)
 
     # ------------------------------------------------------------------
     def run(self, symbol: str, candles: Sequence[Kline]) -> Optional[Signal]:

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -4,6 +4,12 @@ The orchestrator is responsible for discovering strategy implementations at
 runtime, therefore this package only needs to exist so Python treats
 ``modules/`` as a namespace.  Keeping the ``__all__`` list empty prevents us
 from having to update it whenever a new strategy file is added.
+
+Modules that rely on multiple timeframes can opt in without modifying the
+orchestrator: either declare their additional requirements in
+``multi_timeframe_config.MULTI_TIMEFRAME_CONFIG`` or override
+``module_base.ModuleBase.process_with_timeframes`` to consume the
+``extra_candles`` dictionary.
 """
 
 __all__: list[str] = []

--- a/multi_timeframe_config.py
+++ b/multi_timeframe_config.py
@@ -1,0 +1,33 @@
+"""Configuration describing multi-timeframe requirements for modules.
+
+The :data:`MULTI_TIMEFRAME_CONFIG` mapping associates a module abbreviation
+with the additional timeframe data it needs in order to confirm a signal.
+
+Schema
+======
+``MULTI_TIMEFRAME_CONFIG`` is structured as ``{abbreviation: {interval: lookback}}``
+where:
+
+* ``abbreviation`` is the short code used by :class:`module_base.ModuleBase`
+  to identify the module (for example ``"RSI"``).
+* ``interval`` is the Binance-compatible interval string (for example
+  ``"4h"`` or ``"1d"``).
+* ``lookback`` is an integer describing how many candles should be requested
+  for that interval.
+
+Modules that require additional confirmation candles should either declare
+an entry here or provide the extra timeframe information explicitly when
+instantiating :class:`module_base.ModuleBase`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+MultiTimeframeConfig = Dict[str, Dict[str, int]]
+
+# NOTE: The mapping is intentionally empty by default.  Individual projects can
+# populate it with the requirements of their own strategy modules.
+MULTI_TIMEFRAME_CONFIG: MultiTimeframeConfig = {}
+
+__all__ = ["MULTI_TIMEFRAME_CONFIG", "MultiTimeframeConfig"]


### PR DESCRIPTION
## Summary
- add a root-level configuration mapping for declaring extra timeframe requirements
- teach ModuleBase to load multi-timeframe lookbacks and provide a hook that receives all candle sets
- document how strategy modules can opt into the feature via config or the new hook

## Testing
- python -m compileall module_base.py modules/__init__.py multi_timeframe_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d0b69ea0a8832cbd53db7c7e659e61