### PR TITLE
Implement multi-timeframe strategy confirmations

### DIFF
--- a/modules/strategy_bollinger_squeeze.py
+++ b/modules/strategy_bollinger_squeeze.py
@@ -19,7 +19,7 @@ class BollingerSqueezeBreakoutStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "5m",
         lookback: int = 220,
         bollinger_period: int = 20,
         atr_period: int = 14,

--- a/modules/strategy_engulfing_rsi.py
+++ b/modules/strategy_engulfing_rsi.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import math
 from statistics import mean
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from binance_client import Kline
 from module_base import ModuleBase, Signal
 
-from .indicators import atr, rsi
+from .indicators import atr, ema, rsi
 
 
 class EngulfingRSIStrategy(ModuleBase):
@@ -19,17 +19,19 @@ class EngulfingRSIStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "15m",
         lookback: int = 160,
         rsi_period: int = 14,
         atr_period: int = 14,
         atr_average_period: int = 50,
         volume_window: int = 20,
+        trend_ema_period: int = 50,
     ) -> None:
         minimum_history = max(
             rsi_period + 2,
             atr_period + atr_average_period,
             volume_window + 3,
+            trend_ema_period + 2,
         )
         super().__init__(
             client,
@@ -42,21 +44,25 @@ class EngulfingRSIStrategy(ModuleBase):
         self._atr_period = atr_period
         self._atr_average_period = atr_average_period
         self._volume_window = volume_window
+        self._trend_ema_period = trend_ema_period
 
-    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
-        if len(candles) < self.lookback:
+    def _identify_candidates(self, candles: Sequence[Kline]) -> List[Dict[str, object]]:
+        """Detect engulfing setups on the primary timeframe."""
+
+        series = list(candles)
+        if len(series) < self.lookback:
             return []
 
-        previous = candles[-2]
-        current = candles[-1]
+        previous = series[-2]
+        current = series[-1]
 
-        closes = [candle.close for candle in candles]
+        closes = [candle.close for candle in series]
         rsi_values = rsi(closes, self._rsi_period)
         if not rsi_values or math.isnan(rsi_values[-1]):
             return []
         current_rsi = rsi_values[-1]
 
-        atr_values = atr(candles, self._atr_period)
+        atr_values = atr(series, self._atr_period)
         if not atr_values or math.isnan(atr_values[-1]):
             return []
         atr_slice = [
@@ -71,7 +77,7 @@ class EngulfingRSIStrategy(ModuleBase):
         if current_atr <= atr_average:
             return []
 
-        volume_slice = candles[-(self._volume_window + 1) : -1]
+        volume_slice = series[-(self._volume_window + 1) : -1]
         if len(volume_slice) < self._volume_window:
             return []
         average_volume = mean(candle.volume for candle in volume_slice)
@@ -79,7 +85,7 @@ class EngulfingRSIStrategy(ModuleBase):
             return []
         volume_ratio = current.volume / average_volume
 
-        signals: List[Signal] = []
+        candidates: List[Dict[str, object]] = []
 
         bullish_engulf = (
             previous.is_bearish
@@ -106,14 +112,7 @@ class EngulfingRSIStrategy(ModuleBase):
                 "atr_value": current_atr,
                 "volume_ratio": volume_ratio,
             }
-            signals.append(
-                self.make_signal(
-                    symbol,
-                    "LONG",
-                    confidence=1.05,
-                    metadata=metadata,
-                )
-            )
+            candidates.append({"side": "LONG", "metadata": metadata})
 
         if (
             bearish_engulf
@@ -127,10 +126,110 @@ class EngulfingRSIStrategy(ModuleBase):
                 "atr_value": current_atr,
                 "volume_ratio": volume_ratio,
             }
+            candidates.append({"side": "SHORT", "metadata": metadata})
+
+        return candidates
+
+    def _analyse_higher_timeframe(
+        self, candles: Sequence[Kline]
+    ) -> Optional[Tuple[str, Optional[float]]]:
+        series = list(candles)
+        if len(series) < self._trend_ema_period:
+            return None
+
+        closes = [candle.close for candle in series]
+        ema_values = ema(closes, self._trend_ema_period)
+        if not ema_values or math.isnan(ema_values[-1]):
+            return None
+
+        trend = "bullish" if series[-1].close >= ema_values[-1] else "bearish"
+
+        rsi_values = rsi(closes, self._rsi_period)
+        rsi_value = None
+        if rsi_values and not math.isnan(rsi_values[-1]):
+            rsi_value = rsi_values[-1]
+
+        return trend, rsi_value
+
+    def _is_confirmed(self, side: str, context: Tuple[str, Optional[float]]) -> bool:
+        trend, rsi_value = context
+        if side == "LONG":
+            if trend != "bullish":
+                return False
+            if rsi_value is not None and rsi_value > 70:
+                return False
+            return True
+        if trend != "bearish":
+            return False
+        if rsi_value is not None and rsi_value < 30:
+            return False
+        return True
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) < self.lookback:
+            return []
+
+        candidates = self._identify_candidates(candles)
+        return [
+            self.make_signal(
+                symbol,
+                candidate["side"],
+                confidence=1.05,
+                metadata=candidate["metadata"],
+            )
+            for candidate in candidates
+        ]
+
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Mapping[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
+        candidates = self._identify_candidates(primary_candles)
+        if not candidates:
+            return []
+
+        confirmations: List[Tuple[str, Tuple[str, Optional[float]]]] = []
+        for interval in ("30m", "1h"):
+            candles = extra_candles.get(interval)
+            if not candles:
+                continue
+            context = self._analyse_higher_timeframe(candles)
+            if context:
+                confirmations.append((interval, context))
+
+        if not confirmations:
+            return []
+
+        signals: List[Signal] = []
+        for candidate in candidates:
+            side = candidate["side"]
+            metadata = dict(candidate["metadata"])
+            matched_interval: Optional[str] = None
+            matched_context: Optional[Tuple[str, Optional[float]]] = None
+            for interval, context in confirmations:
+                if self._is_confirmed(side, context):
+                    matched_interval = interval
+                    matched_context = context
+                    break
+            if not matched_interval or not matched_context:
+                continue
+
+            trend, rsi_value = matched_context
+            metadata.update(
+                {
+                    "trend_timeframe": matched_interval,
+                    "trend_direction": trend,
+                }
+            )
+            if rsi_value is not None:
+                metadata["higher_rsi"] = rsi_value
+
             signals.append(
                 self.make_signal(
                     symbol,
-                    "SHORT",
+                    side,
                     confidence=1.05,
                     metadata=metadata,
                 )

--- a/modules/strategy_pinbar_level.py
+++ b/modules/strategy_pinbar_level.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
 from binance_client import Kline
 from module_base import ModuleBase, Signal
@@ -18,7 +18,7 @@ class PinBarLevelStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "15m",
         lookback: int = 200,
         ema_period: int = 20,
         rsi_period: int = 14,
@@ -42,81 +42,170 @@ class PinBarLevelStrategy(ModuleBase):
         self._level_window = level_window
         self._level_tolerance = level_tolerance
 
-    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
-        if len(candles) < self.lookback:
-            return []
+    def _identify_pin(self, candles: Sequence[Kline]) -> Dict[str, Dict[str, float]]:
+        """Return pin-bar candidates for ``candles``."""
 
-        pin = candles[-1]
-        closes = [candle.close for candle in candles]
+        result: Dict[str, Dict[str, float]] = {}
+        series = list(candles)
+        if len(series) < self.lookback:
+            return result
+
+        pin = series[-1]
+        closes = [candle.close for candle in series]
 
         ema_values = ema(closes, self._ema_period)
         if not ema_values or math.isnan(ema_values[-1]):
-            return []
+            return result
         ema_current = ema_values[-1]
 
         rsi_values = rsi(closes, self._rsi_period)
         if not rsi_values or math.isnan(rsi_values[-1]):
-            return []
+            return result
         rsi_current = rsi_values[-1]
 
-        level_slice = candles[-self._level_window :]
-        if len(level_slice) < self._level_window:
-            return []
-
-        support_level = min(candle.low for candle in level_slice)
-        resistance_level = max(candle.high for candle in level_slice)
-        tolerance_value_support = support_level * self._level_tolerance if support_level else 0.0
-        tolerance_value_resistance = (
-            resistance_level * self._level_tolerance if resistance_level else 0.0
-        )
-
-        signals: List[Signal] = []
-        body = pin.body
-        body = body if body > 0 else 1e-9
+        body = pin.body if pin.body > 0 else 1e-9
 
         if (
             pin.lower_wick >= 2 * body
             and pin.close > ema_current
             and rsi_current < 30
-            and support_level > 0
-            and abs(pin.low - support_level) <= tolerance_value_support
         ):
-            metadata = {
+            result["LONG"] = {
+                "pin_low": pin.low,
+                "pin_high": pin.high,
                 "pin_ratio": pin.lower_wick / body,
                 "rsi_value": rsi_current,
                 "ema_trend": "bullish",
-                "support_level": support_level,
             }
-            signals.append(
-                self.make_signal(
-                    symbol,
-                    "LONG",
-                    confidence=1.05,
-                    metadata=metadata,
-                )
-            )
 
         if (
             pin.upper_wick >= 2 * body
             and pin.close < ema_current
             and rsi_current > 70
-            and resistance_level > 0
-            and abs(pin.high - resistance_level) <= tolerance_value_resistance
         ):
-            metadata = {
+            result["SHORT"] = {
+                "pin_low": pin.low,
+                "pin_high": pin.high,
                 "pin_ratio": pin.upper_wick / body,
                 "rsi_value": rsi_current,
                 "ema_trend": "bearish",
-                "resistance_level": resistance_level,
             }
-            signals.append(
-                self.make_signal(
-                    symbol,
-                    "SHORT",
-                    confidence=1.05,
-                    metadata=metadata,
+
+        return result
+
+    def _compute_levels(
+        self, candles: Sequence[Kline]
+    ) -> tuple[Optional[float], Optional[float]]:
+        series = list(candles)
+        if len(series) < self._level_window:
+            return None, None
+        window = series[-self._level_window :]
+        support_level = min(candle.low for candle in window)
+        resistance_level = max(candle.high for candle in window)
+        return support_level, resistance_level
+
+    def _build_metadata(
+        self, side: str, context: Dict[str, float], level: float
+    ) -> Dict[str, float]:
+        metadata = {
+            "pin_ratio": context["pin_ratio"],
+            "rsi_value": context["rsi_value"],
+            "ema_trend": context["ema_trend"],
+        }
+        if side == "LONG":
+            metadata["support_level"] = level
+        else:
+            metadata["resistance_level"] = level
+        return metadata
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) < self.lookback:
+            return []
+
+        candidates = self._identify_pin(candles)
+        if not candidates:
+            return []
+
+        support_level, resistance_level = self._compute_levels(candles)
+
+        signals: List[Signal] = []
+
+        long_context = candidates.get("LONG")
+        if long_context and support_level and support_level > 0:
+            tolerance = support_level * self._level_tolerance
+            if abs(long_context["pin_low"] - support_level) <= tolerance:
+                metadata = self._build_metadata("LONG", long_context, support_level)
+                signals.append(
+                    self.make_signal(
+                        symbol,
+                        "LONG",
+                        confidence=1.05,
+                        metadata=metadata,
+                    )
                 )
-            )
+
+        short_context = candidates.get("SHORT")
+        if short_context and resistance_level and resistance_level > 0:
+            tolerance = resistance_level * self._level_tolerance
+            if abs(short_context["pin_high"] - resistance_level) <= tolerance:
+                metadata = self._build_metadata("SHORT", short_context, resistance_level)
+                signals.append(
+                    self.make_signal(
+                        symbol,
+                        "SHORT",
+                        confidence=1.05,
+                        metadata=metadata,
+                    )
+                )
+
+        return signals
+
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Mapping[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
+        candidates = self._identify_pin(primary_candles)
+        if not candidates:
+            return []
+
+        h1_candles = extra_candles.get("1h")
+        if not h1_candles:
+            return []
+
+        support_level, resistance_level = self._compute_levels(h1_candles)
+        signals: List[Signal] = []
+
+        long_context = candidates.get("LONG")
+        if long_context and support_level and support_level > 0:
+            tolerance = support_level * self._level_tolerance
+            if abs(long_context["pin_low"] - support_level) <= tolerance:
+                metadata = self._build_metadata("LONG", long_context, support_level)
+                metadata["level_timeframe"] = "1h"
+                signals.append(
+                    self.make_signal(
+                        symbol,
+                        "LONG",
+                        confidence=1.05,
+                        metadata=metadata,
+                    )
+                )
+
+        short_context = candidates.get("SHORT")
+        if short_context and resistance_level and resistance_level > 0:
+            tolerance = resistance_level * self._level_tolerance
+            if abs(short_context["pin_high"] - resistance_level) <= tolerance:
+                metadata = self._build_metadata("SHORT", short_context, resistance_level)
+                metadata["level_timeframe"] = "1h"
+                signals.append(
+                    self.make_signal(
+                        symbol,
+                        "SHORT",
+                        confidence=1.05,
+                        metadata=metadata,
+                    )
+                )
 
         return signals
 

--- a/modules/strategy_rsi_divergence.py
+++ b/modules/strategy_rsi_divergence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from statistics import mean
-from typing import Iterable, List
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
 from binance_client import Kline
 from module_base import ModuleBase, Signal
@@ -19,7 +19,7 @@ class RSIDivergenceStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "15m",
         lookback: int = 220,
         rsi_period: int = 14,
         divergence_window: int = 30,
@@ -40,20 +40,24 @@ class RSIDivergenceStrategy(ModuleBase):
         self._divergence_window = divergence_window
         self._volume_window = volume_window
 
-    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
-        if len(candles) < self.lookback or len(candles) < self._divergence_window + 2:
-            return []
+    def _analyse_candles(self, candles: Sequence[Kline]) -> Dict[str, Dict[str, float]]:
+        """Compute divergence context for ``candles``."""
 
-        current = candles[-1]
-        closes = [candle.close for candle in candles]
+        result: Dict[str, Dict[str, float]] = {}
+        series = list(candles)
+        if len(series) < self._divergence_window + 2:
+            return result
+
+        current = series[-1]
+        closes = [candle.close for candle in series]
         rsi_values = rsi(closes, self._rsi_period)
         if not rsi_values or math.isnan(rsi_values[-1]):
-            return []
+            return result
         current_rsi = rsi_values[-1]
 
-        prior_candles = candles[-(self._divergence_window + 1) : -1]
-        if len(prior_candles) < self._divergence_window:
-            return []
+        prior_slice = series[-(self._divergence_window + 1) : -1]
+        if len(prior_slice) < self._divergence_window:
+            return result
 
         prior_rsi_values = [
             value
@@ -61,38 +65,103 @@ class RSIDivergenceStrategy(ModuleBase):
             if not math.isnan(value)
         ]
         if not prior_rsi_values:
-            return []
+            return result
 
-        volume_slice = candles[-(self._volume_window + 1) : -1]
-        if len(volume_slice) < self._volume_window:
-            return []
-        average_volume = mean(candle.volume for candle in volume_slice)
-        if average_volume <= 0:
-            return []
-        volume_ratio = current.volume / average_volume
-
-        signals: List[Signal] = []
-
-        prior_lows = [candle.low for candle in prior_candles]
-        prior_highs = [candle.high for candle in prior_candles]
-
+        prior_lows = [candle.low for candle in prior_slice]
+        prior_highs = [candle.high for candle in prior_slice]
         prior_min_low = min(prior_lows)
         prior_max_high = max(prior_highs)
         prior_min_rsi = min(prior_rsi_values)
         prior_max_rsi = max(prior_rsi_values)
 
-        if (
-            current.low < prior_min_low
-            and current_rsi > prior_min_rsi
-            and current_rsi < 30
+        volume_ratio: Optional[float] = None
+        volume_slice = series[-(self._volume_window + 1) : -1]
+        if len(volume_slice) >= self._volume_window:
+            average_volume = mean(candle.volume for candle in volume_slice)
+            if average_volume > 0:
+                volume_ratio = current.volume / average_volume
+
+        result["LONG"] = {
+            "divergence": current.low < prior_min_low and current_rsi > prior_min_rsi,
+            "rsi": current_rsi,
+            "support_level": prior_min_low,
+            "price_divergence": prior_min_low - current.low,
+            "rsi_divergence": current_rsi - prior_min_rsi,
+            "volume_ratio": volume_ratio,
+        }
+        result["SHORT"] = {
+            "divergence": current.high > prior_max_high and current_rsi < prior_max_rsi,
+            "rsi": current_rsi,
+            "resistance_level": prior_max_high,
+            "price_divergence": current.high - prior_max_high,
+            "rsi_divergence": prior_max_rsi - current_rsi,
+            "volume_ratio": volume_ratio,
+        }
+        return result
+
+    def _primary_ready(self, side: str, context: Dict[str, float]) -> bool:
+        volume_ratio = context.get("volume_ratio") or 0.0
+        if side == "LONG":
+            support = float(context.get("support_level") or 0.0)
+            rsi_value = context.get("rsi")
+            return bool(
+                context.get("divergence")
+                and rsi_value is not None
+                and rsi_value < 30
+                and volume_ratio >= 1.0
+                and support > 0
+            )
+        resistance = float(context.get("resistance_level") or 0.0)
+        rsi_value = context.get("rsi")
+        return bool(
+            context.get("divergence")
+            and rsi_value is not None
+            and rsi_value > 70
             and volume_ratio >= 1.0
-        ):
-            metadata = {
-                "rsi_value": current_rsi,
-                "price_divergence": prior_min_low - current.low,
-                "rsi_divergence": current_rsi - prior_min_rsi,
-                "support_level": prior_min_low,
+            and resistance > 0
+        )
+
+    def _build_metadata(self, side: str, context: Dict[str, float]) -> Dict[str, float]:
+        if side == "LONG":
+            return {
+                "rsi_value": context["rsi"],
+                "price_divergence": context["price_divergence"],
+                "rsi_divergence": context["rsi_divergence"],
+                "support_level": context["support_level"],
             }
+        return {
+            "rsi_value": context["rsi"],
+            "price_divergence": context["price_divergence"],
+            "rsi_divergence": context["rsi_divergence"],
+            "resistance_level": context["resistance_level"],
+        }
+
+    def _confirm_long(self, context: Optional[Dict[str, float]]) -> bool:
+        if not context or not context.get("divergence"):
+            return False
+        rsi_value = context.get("rsi")
+        support = context.get("support_level")
+        return bool(rsi_value is not None and rsi_value <= 30 and support and support > 0)
+
+    def _confirm_short(self, context: Optional[Dict[str, float]]) -> bool:
+        if not context or not context.get("divergence"):
+            return False
+        rsi_value = context.get("rsi")
+        resistance = context.get("resistance_level")
+        return bool(rsi_value is not None and rsi_value >= 70 and resistance and resistance > 0)
+
+    def process(self, symbol: str, candles: List[Kline]) -> Iterable[Signal]:
+        if len(candles) < self.lookback or len(candles) < self._divergence_window + 2:
+            return []
+
+        analysis = self._analyse_candles(candles)
+        if not analysis:
+            return []
+
+        signals: List[Signal] = []
+        long_context = analysis.get("LONG")
+        if long_context and self._primary_ready("LONG", long_context):
+            metadata = self._build_metadata("LONG", long_context)
             signals.append(
                 self.make_signal(
                     symbol,
@@ -102,18 +171,79 @@ class RSIDivergenceStrategy(ModuleBase):
                 )
             )
 
+        short_context = analysis.get("SHORT")
+        if short_context and self._primary_ready("SHORT", short_context):
+            metadata = self._build_metadata("SHORT", short_context)
+            signals.append(
+                self.make_signal(
+                    symbol,
+                    "SHORT",
+                    confidence=1.1,
+                    metadata=metadata,
+                )
+            )
+
+        return signals
+
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Mapping[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
+        analysis = self._analyse_candles(primary_candles)
+        if not analysis:
+            return []
+
+        h1_candles = extra_candles.get("1h")
+        if not h1_candles:
+            return []
+
+        higher_analysis = self._analyse_candles(h1_candles)
+        if not higher_analysis:
+            return []
+
+        signals: List[Signal] = []
+
+        long_context = analysis.get("LONG")
+        higher_long = higher_analysis.get("LONG")
         if (
-            current.high > prior_max_high
-            and current_rsi < prior_max_rsi
-            and current_rsi > 70
-            and volume_ratio >= 1.0
+            long_context
+            and self._primary_ready("LONG", long_context)
+            and self._confirm_long(higher_long)
         ):
-            metadata = {
-                "rsi_value": current_rsi,
-                "price_divergence": current.high - prior_max_high,
-                "rsi_divergence": prior_max_rsi - current_rsi,
-                "resistance_level": prior_max_high,
-            }
+            metadata = self._build_metadata("LONG", long_context)
+            metadata.update(
+                {
+                    "confirmation_timeframe": "1h",
+                    "h1_rsi": higher_long["rsi"],
+                    "h1_support_level": higher_long["support_level"],
+                }
+            )
+            signals.append(
+                self.make_signal(
+                    symbol,
+                    "LONG",
+                    confidence=1.1,
+                    metadata=metadata,
+                )
+            )
+
+        short_context = analysis.get("SHORT")
+        higher_short = higher_analysis.get("SHORT")
+        if (
+            short_context
+            and self._primary_ready("SHORT", short_context)
+            and self._confirm_short(higher_short)
+        ):
+            metadata = self._build_metadata("SHORT", short_context)
+            metadata.update(
+                {
+                    "confirmation_timeframe": "1h",
+                    "h1_rsi": higher_short["rsi"],
+                    "h1_resistance_level": higher_short["resistance_level"],
+                }
+            )
             signals.append(
                 self.make_signal(
                     symbol,

--- a/modules/strategy_triple_ema.py
+++ b/modules/strategy_triple_ema.py
@@ -19,7 +19,7 @@ class TripleEMASqueezeStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "5m",
         lookback: int = 220,
         ema_fast_period: int = 9,
         ema_mid_period: int = 21,

--- a/modules/strategy_vwap_reversal.py
+++ b/modules/strategy_vwap_reversal.py
@@ -19,7 +19,7 @@ class VWAPTrendReversalStrategy(ModuleBase):
         self,
         client,
         *,
-        interval: str = "1h",
+        interval: str = "5m",
         lookback: int = 200,
         rsi_period: int = 14,
         volume_window: int = 20,

--- a/multi_timeframe_config.py
+++ b/multi_timeframe_config.py
@@ -26,8 +26,20 @@ from typing import Dict
 
 MultiTimeframeConfig = Dict[str, Dict[str, int]]
 
-# NOTE: The mapping is intentionally empty by default.  Individual projects can
-# populate it with the requirements of their own strategy modules.
-MULTI_TIMEFRAME_CONFIG: MultiTimeframeConfig = {}
+# NOTE: Projects can tailor this mapping to describe the additional timeframe
+# requirements for each strategy module.  The defaults below align the bundled
+# strategies with the multi-timeframe rules described in the documentation.
+MULTI_TIMEFRAME_CONFIG: MultiTimeframeConfig = {
+    # RSI Divergence (DIV) – confirm divergence and RSI extremes on H1.
+    "DIV": {"1h": 220},
+    # Pin Bar + Level + EMA (PIN) – key levels are derived from H1.
+    "PIN": {"1h": 200},
+    # Engulfing + RSI (ENG) – validate trend and momentum on M30/H1.
+    "ENG": {"30m": 160, "1h": 160},
+    # ATR + EMA Breakout (BRK) – trend alignment on H1 via EMA20/EMA50.
+    "BRK": {"1h": 200},
+    # Inside Bar Breakout (INS) – confirm EMA trend on M30.
+    "INS": {"30m": 160},
+}
 
 __all__ = ["MULTI_TIMEFRAME_CONFIG", "MultiTimeframeConfig"]


### PR DESCRIPTION
## Summary
- configure multi-timeframe requirements for RSI divergence, pin bar, engulfing, ATR breakout and inside bar strategies
- refactor strategies to analyse primary signals once and apply higher timeframe confirmations
- align default intervals with specified M5/M15 rules for the bundled strategies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0b852e0e8832c8f7c4c0f245a4221