### PR TITLE
Align trade metadata type with signal metadata

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -45,7 +45,7 @@ class Trade:
     initial_stop: float
     high_watermark: float
     low_watermark: float
-    metadata: Dict[str, float] = field(default_factory=dict)
+    metadata: Dict[str, object] = field(default_factory=dict)
     confidence: float = 1.0
     current_price: Optional[float] = None
     max_profit_pct: float = 0.0


### PR DESCRIPTION
## Summary
- relax the Trade.metadata annotation to accept arbitrary signal metadata values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6bbfa0448832cb50a91ab215ed106