### PR TITLE
Remove close-all-trades button from dashboard

### DIFF
--- a/client.html
+++ b/client.html
@@ -759,7 +759,6 @@
     </main>
 
     <footer class="control-bar">
-      <button class="control-action" type="button" onclick="closeAllTrades()">Закрыть все сделки</button>
     </footer>
   </div>
 
@@ -1345,25 +1344,6 @@
     renderModuleHealth();
     updateUI();
   });
-
-  function closeAllTrades() {
-    if (!ensureSocketConnected()) return;
-
-    socket
-      .timeout(5000)
-      .emit('close_all_trades', {}, (err, response) => {
-        if (err) {
-          alert('Сервер не ответил вовремя');
-          return;
-        }
-        if (response && response.status === 'ok') {
-          alert(`Закрыто ${response.count} сделок`);
-          requestTradesState();
-        } else {
-          alert('Ошибка при закрытии сделок');
-        }
-      });
-  }
 
   function clearCache() {
     if (!ensureSocketConnected()) return;


### PR DESCRIPTION
## Summary
- remove the "Close all trades" button from the dashboard footer
- delete the unused closeAllTrades helper that emitted the close_all_trades event

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7063eb01c832c91700bde8430182f