### PR TITLE
Add default multi-timeframe handler in ModuleBase

### DIFF
--- a/module_base.py
+++ b/module_base.py
@@ -117,6 +117,23 @@ class ModuleBase(ABC):
         """Inspect the provided candles and yield signals."""
 
     # ------------------------------------------------------------------
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
+        """Handle primary + extra timeframe data.
+
+        Strategies that do not require multi-timeframe analysis can rely on
+        this default implementation, which simply delegates to
+        :meth:`process` using the primary candles.  Modules with specific
+        multi-timeframe behaviour should override this method.
+        """
+
+        return self.process(symbol, primary_candles)
+
+    # ------------------------------------------------------------------
     def run(self, symbol: str, candles: Sequence[Kline]) -> Optional[Signal]:
         """Execute the strategy for a single symbol.
 


### PR DESCRIPTION
## Summary
- add a default `process_with_timeframes` implementation that delegates to `process`
- document the delegation behaviour so single-timeframe strategies can run unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d709a4785c832cbae6c8a20631aa39