### PR TITLE
Make multi-timeframe defaults module agnostic

### DIFF
--- a/module_base.py
+++ b/module_base.py
@@ -33,7 +33,8 @@ class ModuleBase(ABC):
     klines and returns zero or more :class:`Signal` instances.  Multi-timeframe
     strategies can either declare their additional requirements via
     ``multi_timeframe_config`` or override :meth:`process_with_timeframes` to
-    handle the extra candle data.
+    handle the extra candle data.  When no extra timeframes are provided the
+    module only fetches the primary interval, keeping the cache module-agnostic.
     """
 
     def __init__(
@@ -46,6 +47,21 @@ class ModuleBase(ABC):
         lookback: int,
         extra_timeframes: Mapping[str, int] | None = None,
     ) -> None:
+        """Create a module description.
+
+        Parameters
+        ----------
+        client:
+            Binance data source used to fetch candles.
+        name / abbreviation / interval / lookback:
+            Basic configuration of the strategy.
+        extra_timeframes:
+            Optional mapping of additional intervals to request.  When omitted
+            the module falls back to :data:`multi_timeframe_config.MULTI_TIMEFRAME_CONFIG`
+            for its abbreviation.  Because the default configuration is empty,
+            modules opt into extra candle fetching explicitly, ensuring the
+            tester remains agnostic to unused strategies.
+        """
         self.client = client
         self.name = name
         self.abbreviation = abbreviation

--- a/multi_timeframe_config.py
+++ b/multi_timeframe_config.py
@@ -15,8 +15,9 @@ where:
 * ``lookback`` is an integer describing how many candles should be requested
   for that interval.
 
-Modules that require additional confirmation candles should either declare
-an entry here or provide the extra timeframe information explicitly when
+By default the configuration is empty so that the caching layer is agnostic to
+which modules are registered.  Individual strategies should either declare an
+entry here or provide the extra timeframe information explicitly when
 instantiating :class:`module_base.ModuleBase`.
 """
 
@@ -27,19 +28,8 @@ from typing import Dict
 MultiTimeframeConfig = Dict[str, Dict[str, int]]
 
 # NOTE: Projects can tailor this mapping to describe the additional timeframe
-# requirements for each strategy module.  The defaults below align the bundled
-# strategies with the multi-timeframe rules described in the documentation.
-MULTI_TIMEFRAME_CONFIG: MultiTimeframeConfig = {
-    # RSI Divergence (DIV) – confirm divergence and RSI extremes on H1.
-    "DIV": {"1h": 220},
-    # Pin Bar + Level + EMA (PIN) – key levels are derived from H1.
-    "PIN": {"1h": 200},
-    # Engulfing + RSI (ENG) – validate trend and momentum on M30/H1.
-    "ENG": {"30m": 160, "1h": 160},
-    # ATR + EMA Breakout (BRK) – trend alignment on H1 via EMA20/EMA50.
-    "BRK": {"1h": 200},
-    # Inside Bar Breakout (INS) – confirm EMA trend on M30.
-    "INS": {"30m": 160},
-}
+# requirements for each strategy module.  The default is intentionally empty so
+# that the tester does not assume the presence of specific built-in modules.
+MULTI_TIMEFRAME_CONFIG: MultiTimeframeConfig = {}
 
 __all__ = ["MULTI_TIMEFRAME_CONFIG", "MultiTimeframeConfig"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for module path adjustments used by unit tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_module_base.py
+++ b/tests/test_module_base.py
@@ -1,0 +1,78 @@
+import unittest
+from typing import Iterable, List
+
+from binance_client import Kline
+from module_base import ModuleBase, Signal
+
+
+class _DummyClient:
+    def __init__(self) -> None:
+        self.calls: List[tuple[str, str, int]] = []
+
+    def fetch_klines(self, symbol: str, interval: str, lookback: int) -> List[Kline]:
+        self.calls.append((symbol, interval, lookback))
+        return [
+            Kline(
+                open_time=index,
+                open=1.0,
+                high=1.5,
+                low=0.5,
+                close=1.2,
+                volume=10.0,
+                close_time=index + 1,
+            )
+            for index in range(lookback)
+        ]
+
+
+class _TestModule(ModuleBase):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.process_calls: List[tuple[str, List[Kline]]] = []
+
+    def process(self, symbol: str, candles: Iterable[Kline]) -> Iterable[Signal]:
+        candles_list = list(candles)
+        self.process_calls.append((symbol, candles_list))
+        return []
+
+
+class ModuleBaseTests(unittest.TestCase):
+    def test_default_configuration_does_not_request_extra_timeframes(self) -> None:
+        client = _DummyClient()
+        module = _TestModule(
+            client,
+            name="Test",
+            abbreviation="TST",
+            interval="1m",
+            lookback=3,
+        )
+
+        signals = module.get_signals(["BTCUSDT"])
+
+        self.assertEqual(signals, [])
+        self.assertEqual(client.calls, [("BTCUSDT", "1m", 3)])
+        self.assertEqual(len(module.process_calls), 1)
+
+    def test_explicit_extra_timeframes_are_respected(self) -> None:
+        client = _DummyClient()
+        module = _TestModule(
+            client,
+            name="Test",
+            abbreviation="TST",
+            interval="1m",
+            lookback=3,
+            extra_timeframes={"1h": 2},
+        )
+
+        signals = module.get_signals(["ETHUSDT"])
+
+        self.assertEqual(signals, [])
+        self.assertEqual(
+            client.calls,
+            [("ETHUSDT", "1m", 3), ("ETHUSDT", "1h", 2)],
+        )
+        self.assertEqual(len(module.process_calls), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- clear the default multi-timeframe configuration so the cache has no strategy-specific knowledge
- document ModuleBase initialisation to highlight explicit opt-in to extra timeframe fetching
- add pytest helpers and unit tests ensuring no extra requests occur when the configuration is empty

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86b887e54832c8cc2996f0ee267b1