### PR TITLE
Format process_with_timeframes signatures

### DIFF
--- a/modules/strategy_bearish_engulfing.py
+++ b/modules/strategy_bearish_engulfing.py
@@ -50,7 +50,12 @@ class BearishEngulfingStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_bullish_engulfing.py
+++ b/modules/strategy_bullish_engulfing.py
@@ -50,7 +50,12 @@ class BullishEngulfingStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_dark_cloud_cover.py
+++ b/modules/strategy_dark_cloud_cover.py
@@ -50,7 +50,12 @@ class DarkCloudCoverStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_hammer.py
+++ b/modules/strategy_hammer.py
@@ -50,7 +50,12 @@ class HammerStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_hanging_man.py
+++ b/modules/strategy_hanging_man.py
@@ -50,7 +50,12 @@ class HangingManStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_inverted_hammer.py
+++ b/modules/strategy_inverted_hammer.py
@@ -50,7 +50,12 @@ class InvertedHammerStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_morning_star.py
+++ b/modules/strategy_morning_star.py
@@ -50,7 +50,12 @@ class MorningStarStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_piercing_line.py
+++ b/modules/strategy_piercing_line.py
@@ -50,7 +50,12 @@ class PiercingLineStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_shooting_star.py
+++ b/modules/strategy_shooting_star.py
@@ -50,7 +50,12 @@ class ShootingStarStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []

--- a/modules/strategy_three_white_soldiers.py
+++ b/modules/strategy_three_white_soldiers.py
@@ -50,7 +50,12 @@ class ThreeWhiteSoldiersStrategy(ModuleBase):
     def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []


### PR DESCRIPTION
## Summary
- format the `process_with_timeframes` method signatures across strategy modules to use a multiline parameter block with the return type on the same line as the function header

## Testing
- python -m compileall modules

------
https://chatgpt.com/codex/tasks/task_e_68dae134e5d4832ca56bcfd4a93fbbee