### PR TITLE
Refine readability of strategy modules

### DIFF
--- a/modules/strategy_bullish_engulfing.py
+++ b/modules/strategy_bullish_engulfing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class BullishEngulfingStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,12 +83,32 @@ class BullishEngulfingStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c1, c2 = candles[-2], candles[-1]
-        if _is_bear(c1) and _is_bull(c2) and c2.close >= c1.open and c2.open <= c1.close:
-            if (_body(c2) / (atr_val or 1e-9)) >= 0.35 and e20 and e50 and e20 > e50:
-                strength = _body(c2)/(atr_val or 1e-9)
-                conf = _confidence(strength)
-                return [self.make_signal(symbol,"LONG",confidence=conf,metadata={"pattern":"bullish_engulfing"})]
+        previous = candles[-2]
+        current = candles[-1]
+
+        closes_inside = (
+            current.close >= previous.open
+            and current.open <= previous.close
+        )
+        pattern_matches = (
+            _is_bear(previous)
+            and _is_bull(current)
+            and closes_inside
+        )
+
+        if pattern_matches and e20 and e50 and e20 > e50:
+            atr_safe = atr_val or 1e-9
+            body_ratio = _body(current) / atr_safe
+
+            if body_ratio >= 0.35:
+                confidence = _confidence(body_ratio)
+                signal = self.make_signal(
+                    symbol,
+                    "LONG",
+                    confidence=confidence,
+                    metadata={"pattern": "bullish_engulfing"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_dark_cloud_cover.py
+++ b/modules/strategy_dark_cloud_cover.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class DarkCloudCoverStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,15 +83,38 @@ class DarkCloudCoverStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c1, c2 = candles[-2], candles[-1]
-        if _is_bull(c1):
-            body1=_body(c1)
-            pen_level=c1.open+body1*0.5
-            if _is_bear(c2) and c2.close<pen_level and c2.open>=c1.high*0.999:
-                if (_body(c2)/(atr_val or 1e-9))>=0.3 and e20 and e50 and e20>e50:
-                    strength=(c1.close-c2.close)/(atr_val or 1e-9)
-                    conf=_confidence(strength)
-                    return [self.make_signal(symbol,"SHORT",confidence=conf,metadata={"pattern":"dark_cloud_cover"})]
+        previous = candles[-2]
+        current = candles[-1]
+
+        if not _is_bull(previous):
+            return []
+
+        body_previous = _body(previous)
+        penetration_level = previous.open + body_previous * 0.5
+        opens_near_high = current.open >= previous.high * 0.999
+        closes_deep = current.close < penetration_level
+
+        if (
+            _is_bear(current)
+            and opens_near_high
+            and closes_deep
+            and e20
+            and e50
+            and e20 > e50
+        ):
+            atr_safe = atr_val or 1e-9
+            body_ratio = _body(current) / atr_safe
+
+            if body_ratio >= 0.3:
+                drop_strength = (previous.close - current.close) / atr_safe
+                confidence = _confidence(drop_strength)
+                signal = self.make_signal(
+                    symbol,
+                    "SHORT",
+                    confidence=confidence,
+                    metadata={"pattern": "dark_cloud_cover"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_hammer.py
+++ b/modules/strategy_hammer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class HammerStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,13 +83,39 @@ class HammerStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c=candles[-1]; prev=candles[-2]
-        body=_body(c); lower=min(c.open,c.close)-c.low; upper=c.high-max(c.open,c.close)
-        if lower>=1.5*body and upper<=0.6*body and _is_bull(c) and c.low<=min(prev.low,candles[-3].low):
-            if (body/(atr_val or 1e-9)>=0.2 or lower/(atr_val or 1e-9)>=0.5) and e20 and e50 and e20<e50:
-                strength=lower/(atr_val or 1e-9)
-                conf=_confidence(strength)
-                return [self.make_signal(symbol,"LONG",confidence=conf,metadata={"pattern":"hammer"})]
+        current = candles[-1]
+        previous = candles[-2]
+        earlier = candles[-3]
+
+        body = _body(current)
+        lower_wick = min(current.open, current.close) - current.low
+        upper_wick = current.high - max(current.open, current.close)
+        atr_safe = atr_val or 1e-9
+
+        has_long_lower_wick = lower_wick >= 1.5 * body
+        has_small_upper_wick = upper_wick <= 0.6 * body
+        makes_new_low = current.low <= min(previous.low, earlier.low)
+        long_conditions = (
+            has_long_lower_wick
+            and has_small_upper_wick
+            and _is_bull(current)
+            and makes_new_low
+        )
+
+        if long_conditions and e20 and e50 and e20 < e50:
+            body_strength = body / atr_safe
+            lower_strength = lower_wick / atr_safe
+            strong_move = body_strength >= 0.2 or lower_strength >= 0.5
+
+            if strong_move:
+                confidence = _confidence(lower_strength)
+                signal = self.make_signal(
+                    symbol,
+                    "LONG",
+                    confidence=confidence,
+                    metadata={"pattern": "hammer"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_hanging_man.py
+++ b/modules/strategy_hanging_man.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class HangingManStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,13 +83,39 @@ class HangingManStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c=candles[-1]; prev=candles[-2]
-        body=_body(c); lower=min(c.open,c.close)-c.low; upper=c.high-max(c.open,c.close)
-        if lower>=1.5*body and upper<=0.6*body and _is_bear(c):
-            if (body/(atr_val or 1e-9)>=0.2 or lower/(atr_val or 1e-9)>=0.5) and e20 and e50 and e20>e50 and c.high>=max(prev.high,candles[-3].high):
-                strength=lower/(atr_val or 1e-9)
-                conf=_confidence(strength)
-                return [self.make_signal(symbol,"SHORT",confidence=conf,metadata={"pattern":"hanging_man"})]
+        current = candles[-1]
+        previous = candles[-2]
+        earlier = candles[-3]
+
+        body = _body(current)
+        lower_wick = min(current.open, current.close) - current.low
+        upper_wick = current.high - max(current.open, current.close)
+        atr_safe = atr_val or 1e-9
+
+        has_long_lower_wick = lower_wick >= 1.5 * body
+        has_small_upper_wick = upper_wick <= 0.6 * body
+        makes_new_high = current.high >= max(previous.high, earlier.high)
+        short_setup = (
+            has_long_lower_wick
+            and has_small_upper_wick
+            and _is_bear(current)
+            and makes_new_high
+        )
+
+        if short_setup and e20 and e50 and e20 > e50:
+            body_strength = body / atr_safe
+            lower_strength = lower_wick / atr_safe
+            strong_move = body_strength >= 0.2 or lower_strength >= 0.5
+
+            if strong_move:
+                confidence = _confidence(lower_strength)
+                signal = self.make_signal(
+                    symbol,
+                    "SHORT",
+                    confidence=confidence,
+                    metadata={"pattern": "hanging_man"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_inverted_hammer.py
+++ b/modules/strategy_inverted_hammer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class InvertedHammerStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,13 +83,33 @@ class InvertedHammerStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c=candles[-1]; body=_body(c)
-        upper=c.high-max(c.open,c.close); lower=min(c.open,c.close)-c.low
-        if upper>=1.6*body and lower<=0.5*body and _is_bull(c):
-            if max(body,upper)/(atr_val or 1e-9)>=0.35 and e20 and e50 and e20<e50:
-                strength=upper/(atr_val or 1e-9)
-                conf=_confidence(strength)
-                return [self.make_signal(symbol,"LONG",confidence=conf,metadata={"pattern":"inverted_hammer"})]
+        current = candles[-1]
+        body = _body(current)
+        upper_wick = current.high - max(current.open, current.close)
+        lower_wick = min(current.open, current.close) - current.low
+        atr_safe = atr_val or 1e-9
+
+        has_long_upper_wick = upper_wick >= 1.6 * body
+        has_small_lower_wick = lower_wick <= 0.5 * body
+        long_setup = (
+            has_long_upper_wick
+            and has_small_lower_wick
+            and _is_bull(current)
+        )
+
+        if long_setup and e20 and e50 and e20 < e50:
+            dominant_move = max(body, upper_wick) / atr_safe
+            strong_move = dominant_move >= 0.35
+
+            if strong_move:
+                confidence = _confidence(upper_wick / atr_safe)
+                signal = self.make_signal(
+                    symbol,
+                    "LONG",
+                    confidence=confidence,
+                    metadata={"pattern": "inverted_hammer"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_piercing_line.py
+++ b/modules/strategy_piercing_line.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class PiercingLineStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,15 +83,34 @@ class PiercingLineStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c1, c2 = candles[-2], candles[-1]
-        if _is_bear(c1):
-            body1 = _body(c1)
-            penetration = c1.open - body1*0.4
-            if _is_bull(c2) and c2.close >= penetration:
-                if (_body(c2)/(atr_val or 1e-9)) >= 0.3 and e20 and e50 and e20 < e50:
-                    strength = _body(c2)/(atr_val or 1e-9)
-                    conf = _confidence(strength)
-                    return [self.make_signal(symbol,"LONG",confidence=conf,metadata={"pattern":"piercing_line"})]
+        previous = candles[-2]
+        current = candles[-1]
+
+        if not _is_bear(previous):
+            return []
+
+        penetration = previous.open - _body(previous) * 0.4
+        closes_above_penetration = current.close >= penetration
+
+        if (
+            _is_bull(current)
+            and closes_above_penetration
+            and e20
+            and e50
+            and e20 < e50
+        ):
+            atr_safe = atr_val or 1e-9
+            body_ratio = _body(current) / atr_safe
+
+            if body_ratio >= 0.3:
+                confidence = _confidence(body_ratio)
+                signal = self.make_signal(
+                    symbol,
+                    "LONG",
+                    confidence=confidence,
+                    metadata={"pattern": "piercing_line"},
+                )
+                return [signal]
         return []
 
 

--- a/modules/strategy_shooting_star.py
+++ b/modules/strategy_shooting_star.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Sequence, Dict
 from binance_client import BinanceClient, Kline
 from module_base import ModuleBase, Signal
-from modules.indicators import ema, atr, rsi, base_metadata, passes_sanity
+from modules.indicators import ema, atr, base_metadata, passes_sanity
 
 def _body(c: Kline) -> float:
     return abs(c.close - c.open)
@@ -47,23 +47,34 @@ class ShootingStarStrategy(ModuleBase):
             extra_timeframes={"30m": 120, "1h": 120}
         )
 
-    def process(self, symbol: str, candles: Sequence[Kline]) -> Iterable[Signal]:
+    def process(
+        self,
+        symbol: str,
+        candles: Sequence[Kline],
+    ) -> Iterable[Signal]:
         return self.process_with_timeframes(symbol, candles, {})
 
-    def process_with_timeframes(self, symbol: str, primary_candles: Sequence[Kline], extra_candles: Dict[str, Sequence[Kline]]) -> Iterable[Signal]:
+    def process_with_timeframes(
+        self,
+        symbol: str,
+        primary_candles: Sequence[Kline],
+        extra_candles: Dict[str, Sequence[Kline]],
+    ) -> Iterable[Signal]:
         candles = primary_candles
         if len(candles) < self.Cfg.lookback:
             return []
 
         meta = base_metadata(candles)
-        if not passes_sanity(meta, min_atr_pct=self.Cfg.min_atr_pct, min_rel_vol=self.Cfg.min_rel_vol):
+        if not passes_sanity(
+            meta,
+            min_atr_pct=self.Cfg.min_atr_pct,
+            min_rel_vol=self.Cfg.min_rel_vol,
+        ):
             return []
 
-        last = candles[-1]
         closes = [c.close for c in candles]
         e20 = _last(ema(closes, 20))
         e50 = _last(ema(closes, 50))
-        e200 = _last(ema(closes, 200))
         atr_val = _last(atr(candles, 14)) or 0.0
 
         # Confirm higher timeframe trend
@@ -72,13 +83,37 @@ class ShootingStarStrategy(ModuleBase):
         if not trend_ok:
             return []
 
-        c=candles[-1]; prev=candles[-2]
-        body=_body(c); upper=c.high-max(c.open,c.close); lower=min(c.open,c.close)-c.low
-        if upper>=1.6*body and lower<=0.5*body and _is_bear(c) and c.high>=prev.high:
-            if max(body,upper)/(atr_val or 1e-9)>=0.35 and e20 and e50 and e20>e50:
-                strength=upper/(atr_val or 1e-9)
-                conf=_confidence(strength)
-                return [self.make_signal(symbol,"SHORT",confidence=conf,metadata={"pattern":"shooting_star"})]
+        current = candles[-1]
+        previous = candles[-2]
+
+        body = _body(current)
+        upper_wick = current.high - max(current.open, current.close)
+        lower_wick = min(current.open, current.close) - current.low
+        atr_safe = atr_val or 1e-9
+
+        has_long_upper_wick = upper_wick >= 1.6 * body
+        has_small_lower_wick = lower_wick <= 0.5 * body
+        pushes_high = current.high >= previous.high
+        short_setup = (
+            has_long_upper_wick
+            and has_small_lower_wick
+            and _is_bear(current)
+            and pushes_high
+        )
+
+        if short_setup and e20 and e50 and e20 > e50:
+            dominant_move = max(body, upper_wick) / atr_safe
+            strong_move = dominant_move >= 0.35
+
+            if strong_move:
+                confidence = _confidence(upper_wick / atr_safe)
+                signal = self.make_signal(
+                    symbol,
+                    "SHORT",
+                    confidence=confidence,
+                    metadata={"pattern": "shooting_star"},
+                )
+                return [signal]
         return []
 
 


### PR DESCRIPTION
## Summary
- remove unused `rsi` imports from the strategy modules
- expand candlestick analysis blocks into descriptive multi-line logic to avoid semicolon chains
- format method signatures and sanity checks to conform to the 79-character guideline

## Testing
- ruff check modules/strategy_*.py

------
https://chatgpt.com/codex/tasks/task_e_68dae13ff804832c81e24302d959f3ee