### PR TITLE
Ensure market snapshot uses compact payload

### DIFF
--- a/binance_client.py
+++ b/binance_client.py
@@ -306,7 +306,7 @@ class BinanceClient:
         try:
             response = self._session.get(
                 f"{BINANCE_REST_ENDPOINT}/api/v3/ticker/24hr",
-                params={"symbols": json.dumps(normalized)},
+                params={"symbols": json.dumps(normalized, separators=(",", ":"))},
                 timeout=10,
             )
             response.raise_for_status()


### PR DESCRIPTION
## Summary
- serialize Binance market snapshot requests with a compact symbols payload
- enhance the recording session test double with ticker fields used by market snapshot parsing
- add a regression test covering whitespace-free payloads and snapshot parsing

## Testing
- pytest tests/test_binance_client.py

------
https://chatgpt.com/codex/tasks/task_e_68daec898d5c832cafbba0cfce223ef5