### PR TITLE
Ensure websocket errors close connections

### DIFF
--- a/binance_client.py
+++ b/binance_client.py
@@ -594,6 +594,14 @@ class BinanceClient:
     def _on_ws_error(self, ws: websocket.WebSocketApp, error: Exception) -> None:
         self._ws_connected.clear()
         _logger.warning("binance websocket error: %s", error)
+        try:
+            ws.keep_running = False
+        except Exception:  # pragma: no cover - defensive
+            pass
+        try:
+            ws.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
 
     def _on_ws_message(self, ws: websocket.WebSocketApp, message: str) -> None:
         try:

--- a/tests/test_binance_client.py
+++ b/tests/test_binance_client.py
@@ -157,5 +157,25 @@ class MarketSnapshotTests(unittest.TestCase):
         )
 
 
+class WebSocketErrorTests(unittest.TestCase):
+    def test_on_ws_error_closes_socket(self) -> None:
+        client = BinanceClient()
+
+        class _FakeWebSocket:
+            def __init__(self) -> None:
+                self.closed = False
+                self.keep_running = True
+
+            def close(self) -> None:
+                self.closed = True
+
+        fake_ws = _FakeWebSocket()
+
+        client._on_ws_error(fake_ws, RuntimeError("boom"))
+
+        self.assertTrue(fake_ws.closed, "websocket should be closed after error")
+        self.assertFalse(fake_ws.keep_running, "keep_running flag should be cleared")
+
+
 if __name__ == "__main__":  # pragma: no cover - manual execution helper
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure the websocket error handler stops the broken connection so it can reconnect
- add a unit test that verifies the handler closes the socket and clears the running flag

## Testing
- python -m unittest tests.test_binance_client

------
https://chatgpt.com/codex/tasks/task_e_68db03a1be50832c9d3490c8e082ef93