### PR TITLE
Send market context with price update events

### DIFF
--- a/client.html
+++ b/client.html
@@ -1426,13 +1426,23 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function handlePriceUpdates(payload) {
     const hasPayload = payload && typeof payload === 'object';
-    if (hasPayload && payload.context) {
-      updateMarketContext(payload.context);
+    let contextApplied = false;
+    if (hasPayload && Object.prototype.hasOwnProperty.call(payload, 'context')) {
+      const contextData = payload.context;
+      if (contextData && typeof contextData === 'object') {
+        updateMarketContext(contextData);
+        contextApplied = true;
+      } else if (contextData === null) {
+        updateMarketContext({});
+        contextApplied = true;
+      }
     }
 
     const incomingTrades = hasPayload && Array.isArray(payload.trades) ? payload.trades : [];
     if (!incomingTrades.length) {
-      updateUI();
+      if (contextApplied) {
+        updateUI();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- capture refreshed market context in the orchestrator when price updates affect tracked symbols
- include the latest context in Socket.IO price updates and emit even when there are no trade changes for context symbols
- make the dashboard accept context-only price updates and refresh its market context accordingly

## Testing
- pytest *(fails: ModuleNotFoundError for optional strategy modules)*

------
https://chatgpt.com/codex/tasks/task_e_68db3377d118832cb1cac1c6752c1f0e