### PR TITLE
Broadcast trend context updates on mode change

### DIFF
--- a/client.html
+++ b/client.html
@@ -1083,23 +1083,43 @@
 
   let trendMode = "global"; // стартовый режим
 
-    function toggleTrendMode() {
-      trendMode = trendMode === "global" ? "local" : "global";
+  function setTrendModeUI(mode) {
+    const normalized = mode === "local" ? "local" : "global";
+    trendMode = normalized;
+    const container = document.getElementById("marketContext");
+    if (container) {
+      container.setAttribute("data-mode", normalized);
+      container.title = `Режим: ${normalized.toUpperCase()}`;
+    }
+  }
 
-      // меняем подпись прямо в панели
-      const container = document.getElementById("marketContext");
-      if (container) {
-        container.setAttribute("data-mode", trendMode);
-        container.title = `Режим: ${trendMode.toUpperCase()}`;
+  function toggleTrendMode() {
+    const previousMode = trendMode;
+    const nextMode = trendMode === "global" ? "local" : "global";
+    setTrendModeUI(nextMode);
+
+    if (!socket || !socket.connected) {
+      return;
+    }
+
+    socket.emit("set_trend_mode", { mode: nextMode }, (response) => {
+      if (!response || response.status !== "ok") {
+        alert("Не удалось переключить режим тренда");
+        setTrendModeUI(previousMode);
+        return;
       }
 
-      if (!socket || !socket.connected) return;
-      socket.emit("set_trend_mode", { mode: trendMode }, (response) => {
-        if (!response || response.status !== "ok") {
-          alert("Не удалось переключить режим тренда");
-        }
-      });
-    }
+      const serverMode =
+        response && typeof response.mode === "string"
+          ? response.mode.toLowerCase()
+          : nextMode;
+      setTrendModeUI(serverMode);
+
+      if (response && response.context) {
+        updateMarketContext(response.context);
+      }
+    });
+  }
 
 document.addEventListener("DOMContentLoaded", () => {
   const ctx = document.getElementById("marketContext");

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -229,7 +229,9 @@ class Orchestrator:
             if mode not in ("global", "local"):
                 return {"status": "error", "message": "invalid mode"}
             self.trend_mode = mode
-            return {"status": "ok", "mode": self.trend_mode}
+            payload = self._broadcast_state()
+            context = payload.get("context") if isinstance(payload, dict) else None
+            return {"status": "ok", "mode": self.trend_mode, "context": context}
 
 
     # ------------------------------------------------------------------
@@ -475,9 +477,10 @@ class Orchestrator:
         return trade.to_dict()
 
     # ------------------------------------------------------------------
-    def _broadcast_state(self) -> None:
+    def _broadcast_state(self) -> Dict[str, object]:
         payload = self._serialize_state()
         self.socketio.emit("trades", payload)
+        return payload
 
     # ------------------------------------------------------------------
     def close_all_trades(self) -> int:


### PR DESCRIPTION
## Summary
- broadcast the latest state immediately after changing the trend mode
- include market context in the set_trend_mode ACK and consume it in the dashboard toggle handler

## Testing
- pytest *(fails: missing optional strategy modules in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68db3383fd14832caf799bba2adbf046