### PR TITLE
Handle trade_closed websocket updates in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ started without a previously cached liquidity snapshot it automatically falls
 back to a small offline list of symbols (``BTCUSDT``/``ETHUSDT`` by default).
 The fallback list can be overridden by passing ``offline_pairs`` to
 ``BinanceClient`` or wiring the parameter through your own configuration.
+
+## Manual QA
+
+- **Closed trade push event:** Open the dashboard, ensure at least one active
+  trade is visible, and emit only a ``trade_closed`` Socket.IO event for that
+  trade (without broadcasting a full ``trades`` snapshot). Confirm that the
+  position disappears from the «Активные сделки» table, reappears under
+  «Закрытые сделки» and that aggregate statistics update instantly.

--- a/client.html
+++ b/client.html
@@ -1552,6 +1552,76 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     socket.on('trades', handleTradesPayload);
+    socket.on('trade_closed', (payload) => {
+      let normalizedSource = {};
+      if (Array.isArray(payload)) {
+        normalizedSource = { closed: payload };
+      } else if (payload && typeof payload === 'object') {
+        if (Array.isArray(payload.closed)) {
+          normalizedSource = { closed: payload.closed };
+        } else if (payload.closed && typeof payload.closed === 'object') {
+          normalizedSource = { closed: [payload.closed] };
+        } else if (payload.trade && typeof payload.trade === 'object') {
+          normalizedSource = { closed: [payload.trade] };
+        } else {
+          normalizedSource = { closed: [payload] };
+        }
+      }
+
+      const normalized = normalizeTradesData(normalizedSource);
+      const updates = normalized.closed;
+      if (!updates.length) {
+        return;
+      }
+
+      const activeMap = new Map();
+      tradesData.active.forEach((trade) => {
+        activeMap.set(getTradeKey(trade), trade);
+      });
+
+      const closedMap = new Map();
+      tradesData.closed.forEach((trade) => {
+        closedMap.set(getTradeKey(trade), trade);
+      });
+
+      const toRemoveActive = new Set();
+
+      updates.forEach((update) => {
+        const key = getTradeKey(update);
+        const activeMatch = activeMap.get(key);
+        if (activeMatch) {
+          toRemoveActive.add(activeMatch);
+          activeMap.delete(key);
+        }
+
+        const existingClosed = closedMap.get(key);
+        if (existingClosed) {
+          Object.assign(existingClosed, update);
+        } else {
+          const clone = { ...update };
+          tradesData.closed.push(clone);
+          closedMap.set(key, clone);
+        }
+      });
+
+      if (toRemoveActive.size) {
+        tradesData.active = tradesData.active.filter((trade) => !toRemoveActive.has(trade));
+      }
+
+      const parseTime = (value) => {
+        if (!value) return 0;
+        const timestamp = Date.parse(value);
+        return Number.isNaN(timestamp) ? 0 : timestamp;
+      };
+
+      tradesData.closed.sort(
+        (a, b) =>
+          parseTime(b.exit_time || b.entry_time) -
+          parseTime(a.exit_time || a.entry_time)
+      );
+
+      updateUI();
+    });
     socket.on('prices_updated', handlePriceUpdates);
   }
 


### PR DESCRIPTION
## Summary
- listen for `trade_closed` websocket events and merge the payload into the dashboard state while pruning any matching active trades
- refresh the UI immediately after closed-trade pushes so the tables and statistics stay in sync
- add a manual QA note describing how to verify closed-trade push updates without a snapshot

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db3940d8b8832cb3dc5d0d071bdc7b